### PR TITLE
fix: missing abc.abstractmethod tags in AdapterInterface

### DIFF
--- a/adapters/AdapterInterface.py
+++ b/adapters/AdapterInterface.py
@@ -3,7 +3,6 @@ from typing import List, Union, Optional
 
 from models.Facility import Facility
 from models.Group import Group
-from models.HasIdAbstract import HasIdAbstract
 from models.User import User
 from models.UserExtSource import UserExtSource
 from models.VO import VO
@@ -55,8 +54,6 @@ class AdapterInterface(metaclass=abc.ABCMeta):
                 and callable(subclass.get_resource_capabilities)
                 and hasattr(subclass, "get_facility_capabilities")
                 and callable(subclass.get_facility_capabilities)
-                and hasattr(subclass, "unique_entities")
-                and callable(subclass.unique_entities)
                 or NotImplemented
         )
 
@@ -65,70 +62,83 @@ class AdapterInterface(metaclass=abc.ABCMeta):
         """Get Perun user with at least one of the uids"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_group_by_name(self, vo: VO, name: str) -> Group:
         """Get Group based on its name"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_vo(self, short_name=None, id=None) -> VO:
         """Get VO by either its id or short name"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_member_groups(self, user: User, vo: VO) -> List[Group]:
         """Get member groups of given user"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_sp_groups(self, rp_identifier: str) -> List[Group]:
         """Get groups associated withs given SP entity"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_user_attributes(
             self, user: User, attr_names: List[str]
     ) -> dict[str, Union[str, Optional[int], bool, List[str], dict[str, str]]]:
         """Get specified attributes of given user"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_entityless_attribute(
             self, attr_name: str
     ) -> Union[str, Optional[int], bool, List[str], dict[str, str]]:
         """Get value of given entityless attribute"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_vo_attributes(
             self, vo: VO, attr_names: List[str]
     ) -> dict[str, Union[str, Optional[int], bool, List[str], dict[str, str]]]:
         """Get specified attributes of given VO"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_facility_attribute(
             self, facility: Facility, attr_name: str
     ) -> Union[str, Optional[int], bool, List[str], dict[str, str]]:
         """Get specified attribute of given facility"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_facility_by_rp_identifier(
             self, rp_identifier: str, rp_identifier_attr: str
     ) -> Facility:
         """Get specified facility based on given rp_identifier"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_users_groups_on_facility(
-            self, rp_identifier: str, user_id: str
+            self, rp_identifier: str, user: User
     ) -> List[Group]:
         """Get groups of specified user on given facility"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_facilities_by_attribute_value(
             self, attribute: dict[str, str]
     ) -> List[Facility]:
         """Search facilities based on given attribute value"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_facility_attributes(
             self, facility: Facility, attr_names: List[str]
     ) -> dict[str, Union[str, Optional[int], bool, List[str], dict[str, str]]]:
         """Get specified attributes of given facility"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_user_ext_source(
             self, ext_source_name: str, ext_source_login: str
     ) -> UserExtSource:
@@ -136,10 +146,12 @@ class AdapterInterface(metaclass=abc.ABCMeta):
         login"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def update_user_ext_source_last_access(self, user_ext_source: str) -> None:
         """Update user's last access of external source"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_user_ext_source_attributes(
             self, user_ext_source: UserExtSource,
             attributes: List[dict[str, str]]
@@ -147,6 +159,7 @@ class AdapterInterface(metaclass=abc.ABCMeta):
         """Get attributes of user's external source"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def set_user_ext_source_attributes(
             self, user_ext_source: UserExtSource,
             attributes: List[dict[str, str]]
@@ -154,14 +167,17 @@ class AdapterInterface(metaclass=abc.ABCMeta):
         """Set attributes of user's external source"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_member_status_by_user_and_vo(self, user: User, vo: VO) -> str:
         """Get member's status based on given User and VO"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def is_user_in_vo(self, user: User, vo_short_name: str) -> bool:
         """Verifies whether given User is in given VO"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_resource_capabilities(
             self, rp_identifier: str, user_groups: List[Group]
     ) -> List[str]:
@@ -169,12 +185,7 @@ class AdapterInterface(metaclass=abc.ABCMeta):
         with given entity ID"""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_facility_capabilities(self, rp_identifier: str) -> List[str]:
         """Obtains facility capabilities of facility with given entity ID"""
-        raise NotImplementedError
-
-    def unique_entities(
-            self, entities: List[HasIdAbstract]
-    ) -> List[HasIdAbstract]:
-        """Returns objects with IDs of unique entities in input list"""
         raise NotImplementedError


### PR DESCRIPTION
AdapterInterfface subclasses now cannot be instantiated without implementing all AdapterInterace methods.